### PR TITLE
Change share to standard pointer, so table obj can clear it. #12

### DIFF
--- a/src/crunch.cpp
+++ b/src/crunch.cpp
@@ -516,20 +516,20 @@ int crunch::create(const char *name, TABLE *table_arg, HA_CREATE_INFO *create_in
   they are needed to function.
 */
 
-std::unique_ptr<crunch_share> crunch::get_share()
+crunch_share* crunch::get_share()
 {
-  std::unique_ptr<crunch_share> tmp_share;
+  crunch_share* tmp_share;
 
   DBUG_ENTER("crunch::get_share()");
 
   lock_shared_ha_data();
-  if (!(tmp_share= std::unique_ptr<crunch_share>(static_cast<crunch_share*>(get_ha_share_ptr()))))
+  if (!(tmp_share= static_cast<crunch_share*>(get_ha_share_ptr())))
   {
-    tmp_share= std::unique_ptr<crunch_share>(new crunch_share);
+    tmp_share= new crunch_share;
     if (!tmp_share)
       goto err;
 
-    set_ha_share_ptr(static_cast<Handler_share*>(tmp_share.get()));
+    set_ha_share_ptr(static_cast<Handler_share*>(tmp_share));
   }
   err:
   unlock_shared_ha_data();

--- a/src/crunch.hpp
+++ b/src/crunch.hpp
@@ -111,8 +111,8 @@ private:
     bool mremapData();
 
     THR_LOCK_DATA lock;      ///< MySQL lock
-    std::unique_ptr<crunch_share> share;    ///< Shared lock info
-    std::unique_ptr<crunch_share> get_share(); ///< Get the share
+    crunch_share* share;    ///< Shared lock info
+    crunch_share* get_share(); ///< Get the share
 
     ::capnp::ParsedSchema capnpParsedSchema;
     ::capnp::StructSchema capnpRowSchema;


### PR DESCRIPTION
This changes from a unique prt to a standard pointer so the Table obj can clear the share in the destructor.

This will all be replaced when proper locking is implemented. #13

Closes #12