### PR TITLE
Disable all irrelevant storage engines from building for ci tests. #33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ script:
   - cd mariadb-10.2.7
   - mkdir build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=Release .. 
+  - cmake -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release ..
   - make -j24
   - ./mysql-test/mysql-test-run.pl  --suite=crunch


### PR DESCRIPTION
Closes #33